### PR TITLE
Extended proof of concept

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*.{cpp,h}]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/Ashigaru/Ashigaru/Ashigaru.vcxproj
+++ b/Ashigaru/Ashigaru/Ashigaru.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="..\..\include\render_action.h" />
     <ClInclude Include="..\..\include\render_server.h" />
     <ClInclude Include="..\..\include\tiled_view.h" />
+    <ClInclude Include="..\..\include\triple_action.h" />
     <ClInclude Include="..\..\include\util.h" />
     <ClInclude Include="..\..\include\vertex_db.h" />
     <ClInclude Include="targetver.h" />
@@ -162,6 +163,7 @@
     <None Include="..\..\shaders\passthrough.vertex.glsl" />
     <None Include="..\..\shaders\take_min.glsl" />
     <None Include="..\..\shaders\vertex.glsl" />
+    <None Include=".editorconfig" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -170,6 +172,7 @@
     <ClCompile Include="..\..\src\render_action.cpp" />
     <ClCompile Include="..\..\src\render_server.cpp" />
     <ClCompile Include="..\..\src\tiled_view.cpp" />
+    <ClCompile Include="..\..\src\triple_action.cpp" />
     <ClCompile Include="..\..\src\util.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/Ashigaru/Ashigaru/Ashigaru.vcxproj
+++ b/Ashigaru/Ashigaru/Ashigaru.vcxproj
@@ -159,17 +159,18 @@
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\.editorconfig" />
     <None Include="..\..\shaders\frag.glsl" />
+    <None Include="..\..\shaders\height_frag.glsl" />
+    <None Include="..\..\shaders\height_geom.glsl" />
     <None Include="..\..\shaders\passthrough.vertex.glsl" />
     <None Include="..\..\shaders\take_min.glsl" />
     <None Include="..\..\shaders\vertex.glsl" />
-    <None Include=".editorconfig" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\main.cpp" />
     <ClCompile Include="..\..\src\opengl_utils.cpp" />
-    <ClCompile Include="..\..\src\render_action.cpp" />
     <ClCompile Include="..\..\src\render_server.cpp" />
     <ClCompile Include="..\..\src\tiled_view.cpp" />
     <ClCompile Include="..\..\src\triple_action.cpp" />

--- a/Ashigaru/Ashigaru/Ashigaru.vcxproj.filters
+++ b/Ashigaru/Ashigaru/Ashigaru.vcxproj.filters
@@ -42,6 +42,9 @@
     <ClInclude Include="..\..\include\vertex_db.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\triple_action.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
@@ -57,6 +60,7 @@
     <None Include="..\..\shaders\take_min.glsl">
       <Filter>Shaders</Filter>
     </None>
+    <None Include=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\main.cpp">
@@ -75,6 +79,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\util.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\src\triple_action.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Ashigaru/Ashigaru/Ashigaru.vcxproj.filters
+++ b/Ashigaru/Ashigaru/Ashigaru.vcxproj.filters
@@ -60,16 +60,19 @@
     <None Include="..\..\shaders\take_min.glsl">
       <Filter>Shaders</Filter>
     </None>
-    <None Include=".editorconfig" />
+    <None Include="..\..\.editorconfig" />
+    <None Include="..\..\shaders\height_frag.glsl">
+      <Filter>Shaders</Filter>
+    </None>
+    <None Include="..\..\shaders\height_geom.glsl">
+      <Filter>Shaders</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\opengl_utils.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\src\render_action.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\src\render_server.cpp">

--- a/include/opengl_utils.h
+++ b/include/opengl_utils.h
@@ -1,4 +1,4 @@
 #pragma once
 #include <GL/glew.h>
 
-GLuint LoadShaders(const char * vertex_file_path, const char * fragment_file_path);
+GLuint LoadShaders(const char* vertex_file_path, const char* fragment_file_path=nullptr, const char* geom_file_path=nullptr);

--- a/include/triple_action.h
+++ b/include/triple_action.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "render_action.h"
+
+namespace Ashigaru {
+    
+    class TripleAction : public RenderAction {
+        unsigned int m_width, m_height;
+        size_t m_slice;
+        
+        // 3 renders per tile, generating 3 maps. 
+        // currently considering no priorities (which would require more renders).
+        GLuint m_height_program, m_stencil_program, m_color_program;
+        GLuint m_height_fbo;
+        
+        // Scratch data for rendering. Generated in preparation of slice or tile,
+        // and used in the actual rendering.
+        glm::mat4 m_look_up, m_look_down;
+        
+    public:
+        TripleAction(unsigned int width, unsigned int height);
+        
+        virtual void InitGL() override;
+        virtual bool PrepareTile(Rect<unsigned int> tile_rect) override;
+        virtual bool PrepareSlice(size_t slice_num) override { m_slice = slice_num; return true; }
+        virtual std::vector<RenderAsyncResult> StartRender(VertexDB vertices) override;
+        
+        virtual std::vector<unsigned int> OutputPixelSizes() const override { return std::vector<unsigned int>{2}; }
+        
+    private:
+        /* CommitBufferAsync() starts a read from GL to memory of one of the buffers in the frame buffer.
+        * It generates the pair of fence/PBO required by external code to track completion and act of 
+        * the copied buffer.
+        * Assumes that a proper FBO is bound.
+        * 
+        * Arguments:
+        * which - designation of the read buffer as would be given to glReadBuffer (e.g. GL_COLOR_ATTACHMENT0)
+        * elem_size - bytes per pixel in the read buffer.
+        * format, type - passed along to glReadPixels(), so see that.
+        */
+        RenderAsyncResult CommitBufferAsync(GLenum which, unsigned short elem_size, GLenum format,  GLenum type);
+    };
+    
+}

--- a/include/triple_action.h
+++ b/include/triple_action.h
@@ -11,11 +11,11 @@ namespace Ashigaru {
         // 3 renders per tile, generating 3 maps. 
         // currently considering no priorities (which would require more renders).
         GLuint m_height_program, m_stencil_program, m_color_program;
-        GLuint m_height_fbo;
+        GLuint m_height_fbo, m_stencil_fbo;
         
         // Scratch data for rendering. Generated in preparation of slice or tile,
         // and used in the actual rendering.
-        glm::mat4 m_look_up, m_look_down;
+        glm::mat4 m_look_up, m_look_down, m_crop_up;
         
     public:
         TripleAction(unsigned int width, unsigned int height);
@@ -25,7 +25,7 @@ namespace Ashigaru {
         virtual bool PrepareSlice(size_t slice_num) override { m_slice = slice_num; return true; }
         virtual std::vector<RenderAsyncResult> StartRender(VertexDB vertices) override;
         
-        virtual std::vector<unsigned int> OutputPixelSizes() const override { return std::vector<unsigned int>{2, 2}; }
+        virtual std::vector<unsigned int> OutputPixelSizes() const override { return std::vector<unsigned int>{2, 2, 2}; }
         
     private:
         /* CommitBufferAsync() starts a read from GL to memory of one of the buffers in the frame buffer.

--- a/include/triple_action.h
+++ b/include/triple_action.h
@@ -25,7 +25,7 @@ namespace Ashigaru {
         virtual bool PrepareSlice(size_t slice_num) override { m_slice = slice_num; return true; }
         virtual std::vector<RenderAsyncResult> StartRender(VertexDB vertices) override;
         
-        virtual std::vector<unsigned int> OutputPixelSizes() const override { return std::vector<unsigned int>{2}; }
+        virtual std::vector<unsigned int> OutputPixelSizes() const override { return std::vector<unsigned int>{2, 2}; }
         
     private:
         /* CommitBufferAsync() starts a read from GL to memory of one of the buffers in the frame buffer.

--- a/include/vertex_db.h
+++ b/include/vertex_db.h
@@ -11,7 +11,7 @@
  *    by the application.
  * 2. TiledView can do vertex selections without knowing what each vertex 
  *    carries. In the future, it will enable RenderAction to produce the 
- *    full image data from models, while ?TiledView will only do the 
+ *    full image data from models, while TiledView will only do the 
  *    filtering. Alternatively, TiledView will construct a DB with pos and ID, 
  *    then RenderAction will load it with whatever else based on that data.
  * 3. We can add to this class vertex indexing/selection such that we can 
@@ -22,25 +22,23 @@
 
 class VertexDB {
     std::map<std::string, GLuint> m_buffers;
-    unsigned int m_num_verts;
+    std::vector<std::pair<size_t, size_t>> m_model_index; // (first vertex index, block length)
     
 public:
-    VertexDB() : m_num_verts{0} {}
-    VertexDB(unsigned int num_verts) : m_num_verts{num_verts} {}
-    VertexDB(unsigned int num_verts, std::map<std::string, GLuint> buffs) 
-		: m_num_verts(num_verts) 
+    VertexDB()  {}
+    VertexDB(std::map<std::string, GLuint> buffs) 
 	{
 		m_buffers = buffs;
 	}
     
-    void SetNumVerts(unsigned int num_verts) {
-        if (m_buffers.size() != 0)
-            throw std::runtime_error("Attempt to resize GL buffers.");
-        m_num_verts = num_verts;
-    }
     void AddBuffers(const std::map<std::string, GLuint>& buffs) { m_buffers.insert(buffs.begin(), buffs.end()); }
     void AddBuffer(const std::string& name, GLuint buff) { m_buffers[name] = buff; }
-    
     GLuint GetBuffer(const std::string& name) const { return m_buffers.at(name); }
-    unsigned int VertexCount() { return m_num_verts; }
+
+    // Adds a bookmark for block of vertices, using indices into the vertex buffer
+    // recorded by AddBuffer*(). This is very rudimentary now, just to try things out.
+    void AddModelIndex(size_t start, size_t length) {
+        m_model_index.push_back(std::make_pair(start, length));
+    }
+    const std::vector<std::pair<size_t, size_t>>& GetModelIndex() const { return m_model_index; }
 };

--- a/shaders/frag.glsl
+++ b/shaders/frag.glsl
@@ -1,6 +1,6 @@
 #version 330 core
 
-flat in uint shellID;
+uniform uint shellID;
 out vec4 color;
 
 void main(){

--- a/shaders/height_frag.glsl
+++ b/shaders/height_frag.glsl
@@ -1,8 +1,8 @@
 #version 330 core
 
-flat in uint shellID_out;
+uniform uint shellID;
 out vec4 color;
 
 void main(){
-    color = vec4(float(shellID_out + 1u)*0.3, 0, 0, 1);
+    color = vec4(float(shellID + 1u)*0.3, 0, 0, 1);
 }

--- a/shaders/height_frag.glsl
+++ b/shaders/height_frag.glsl
@@ -1,0 +1,8 @@
+#version 330 core
+
+flat in uint shellID_out;
+out vec4 color;
+
+void main(){
+    color = vec4(float(shellID_out + 1u)*0.3, 0, 0, 1);
+}

--- a/shaders/height_geom.glsl
+++ b/shaders/height_geom.glsl
@@ -3,9 +3,6 @@
 layout (triangles) in;
 layout (triangle_strip, max_vertices=6) out;
 
-flat in uint shellID[];
-flat out uint shellID_out;
-
 void main()
 {
     // Pass-through.
@@ -13,7 +10,6 @@ void main()
     {
         for (int i = 0; i < 3; i++) {
             gl_Position = gl_in[i].gl_Position;
-            shellID_out = shellID[i];
             EmitVertex();
         }
         EndPrimitive();
@@ -24,7 +20,6 @@ void main()
     {
         for (int i = 0; i < 3; i++) {
             gl_Position = vec4( gl_in[i].gl_Position.xy, -gl_in[i].gl_Position.z, 1.);
-            shellID_out = shellID[i];
             EmitVertex();
         }
         EndPrimitive();

--- a/shaders/height_geom.glsl
+++ b/shaders/height_geom.glsl
@@ -1,0 +1,27 @@
+#version 330 core
+
+layout (triangles) in;
+layout (triangle_strip, max_vertices=6) out;
+
+void main()
+{
+    // Pass-through.
+    if (gl_in[0].gl_Position.z >= 0 || gl_in[1].gl_Position.z >= 0 || gl_in[2].gl_Position.z >= 0)
+    {
+        for (int i = 0; i < 3; i++) {
+            gl_Position = gl_in[i].gl_Position;
+            EmitVertex();
+        }
+        EndPrimitive();
+    }
+    
+    // Mirror the faces below slice height. 
+    if (gl_in[0].gl_Position.z < 0 || gl_in[1].gl_Position.z < 0 || gl_in[2].gl_Position.z < 0)
+    {
+        for (int i = 0; i < 3; i++) {
+            gl_Position = vec4( gl_in[i].gl_Position.xy, -gl_in[i].gl_Position.z, 1.);
+            EmitVertex();
+        }
+        EndPrimitive();
+    }
+}

--- a/shaders/height_geom.glsl
+++ b/shaders/height_geom.glsl
@@ -3,6 +3,9 @@
 layout (triangles) in;
 layout (triangle_strip, max_vertices=6) out;
 
+flat in uint shellID[];
+flat out uint shellID_out;
+
 void main()
 {
     // Pass-through.
@@ -10,6 +13,7 @@ void main()
     {
         for (int i = 0; i < 3; i++) {
             gl_Position = gl_in[i].gl_Position;
+            shellID_out = shellID[i];
             EmitVertex();
         }
         EndPrimitive();
@@ -20,6 +24,7 @@ void main()
     {
         for (int i = 0; i < 3; i++) {
             gl_Position = vec4( gl_in[i].gl_Position.xy, -gl_in[i].gl_Position.z, 1.);
+            shellID_out = shellID[i];
             EmitVertex();
         }
         EndPrimitive();

--- a/shaders/vertex.glsl
+++ b/shaders/vertex.glsl
@@ -1,14 +1,10 @@
 #version 330 core
 
 layout(location = 0) in vec3 vertexPosition_modelspace;
-layout(location = 1) in uint vertex_shellID;
 
 uniform mat4 projection;
-
-flat out uint shellID;
 
 void main()
 {
 	gl_Position = projection*vec4(vertexPosition_modelspace, 1);
-	shellID = vertex_shellID;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,8 @@ int main(int argc, char **argv) {
 
     po::options_description desc("Allowed options");
     desc.add_options()
+            ("model-path", po::value<std::string>(), "STL file to render.")
+            ("repeats", po::value<unsigned int>()->default_value(1u), "The model will be repeated this many columns and this many rows.")
             ("img-size", po::value<unsigned int>()->default_value(2048u), "Side of square image generated.")
             ("tile-size", po::value<unsigned int>()->default_value(1024u), "Side of square tile for rendering.")
             ("slice", po::value<size_t>()->default_value(0u))
@@ -41,12 +43,13 @@ int main(int argc, char **argv) {
     // A shaderProgram is responsible for drawing into its own frame buffer.
     unsigned int width = vm["img-size"].as<unsigned int>();
     unsigned int height = width;
-    unsigned int tile_width = vm["tile-size"].as <unsigned int>();
+    unsigned int tile_width = vm["tile-size"].as<unsigned int>();
     unsigned int tile_height = tile_width;
+    unsigned int repeats = vm["repeats"].as<unsigned int>();
     
     // Load a model, do Q&D size-to-fit and then duplicate it.
     // the two models are the (possibly) rendered scene.
-    std::shared_ptr<Model> geometry = std::make_shared<Model>(readBinarySTL("models/Donkey.stl"));
+    std::shared_ptr<Model> geometry = std::make_shared<Model>( readBinarySTL(vm["model-path"].as<std::string>().c_str()) );
     Vertex maxV{ 0., 0., 0. }, minV{ 20000, 20000, 20000 };
     for (auto& vertex : geometry->first) // find bounding box
     {
@@ -55,17 +58,29 @@ int main(int argc, char **argv) {
     }
     glm::vec3 dims = maxV - minV;
 	Vertex::value_type maxDim = std::max({ dims.x, dims.y, dims.z });
-    glm::vec3 scale_factor = {width, width, width};
+
+	float targetModelWidth = float(width) / float(repeats);
+    glm::vec3 scale_factor = { targetModelWidth, targetModelWidth, targetModelWidth };
 	for (auto& vertex : geometry->first) {
 		vertex = (vertex - minV) / maxDim * scale_factor;
 	}
 	std::cout << glm::to_string(minV) << std::endl;
 	std::cout << glm::to_string(maxV) << std::endl;
-    
-    std::shared_ptr<Model> partner_geom {new Model{*geometry}};
-    for (auto& vertex : partner_geom->first) {
-        vertex.x += width;
-    }
+
+    // replicate the model for all repeats, moving the vertices accordingly.
+    // This might be handled with a transform later, but not now.
+	std::vector<std::shared_ptr<Model>> duplicateModels;
+	for (unsigned int row = 0; row < repeats; ++row) {
+		for (unsigned int col = 0; col < repeats; ++col) {
+			std::shared_ptr<Model> model_ptr{ new Model{ *geometry } };
+			duplicateModels.push_back(model_ptr);
+
+			for (auto& vertex : duplicateModels.back()->first) {
+				vertex.x += targetModelWidth * col;
+				vertex.y += targetModelWidth * row;
+			}
+		}
+	}
     
     // Start the render server:
     Ashigaru::RenderServer server(tile_width, tile_height);
@@ -73,8 +88,8 @@ int main(int argc, char **argv) {
     // Create the view we want to render:
     Ashigaru::TripleAction program{tile_width, tile_height};
     
-    auto models = server.RegisterModels(std::vector<std::shared_ptr<Model>>{geometry, partner_geom});
-    auto view = server.RegisterView(program, 2*width, height, models).get();
+    auto models = server.RegisterModels(duplicateModels);
+    auto view = server.RegisterView(program, width, height, models).get();
     
     // Render slices:
 	std::cout << "Slicing: " << std::endl;
@@ -83,7 +98,8 @@ int main(int argc, char **argv) {
 		std::vector<std::vector<std::future<std::unique_ptr<char>>>> slices;
 
 		auto start = std::chrono::system_clock::now();
-		for (size_t slice = 0; slice < 100; ++slice) {
+		size_t num_slices = 10;
+		for (size_t slice = 0; slice < num_slices; ++slice) {
 			slices.push_back(server.ViewSlice(view, slice));
 		}
 		auto end = std::chrono::system_clock::now();
@@ -97,20 +113,20 @@ int main(int argc, char **argv) {
 		}
 		auto fullEnd = std::chrono::system_clock::now();
 
-		std::cout << "Sending slice instructions: " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << std::endl;
-		std::cout << "Finish all slices: " << std::chrono::duration_cast<std::chrono::milliseconds>(fullEnd - start).count() << std::endl;
+		std::cout << "Sending slice instructions: " << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count()/num_slices << std::endl;
+		std::cout << "Finish all slices: " << std::chrono::duration_cast<std::chrono::milliseconds>(fullEnd - start).count()/num_slices << std::endl;
 	}
 	else {
 		std::vector<std::future<std::unique_ptr<char>>> res = server.ViewSlice(view, vm["slice"].as<size_t>());
 		// wait for results and save them:
 		std::unique_ptr<char> data = std::move(res[0].get());
-		writeImage("height.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru height");
+		writeImage("height.png", width, height, ImageType::Gray, data.get(), "Ashigaru height");
 
 		data = res[1].get();
-		writeImage("heightID.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru height ID");
+		writeImage("heightID.png", width, height, ImageType::Gray, data.get(), "Ashigaru height ID");
         
         data = res[2].get();
-		writeImage("cross.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru cross section");
+		writeImage("cross.png", width, height, ImageType::Gray, data.get(), "Ashigaru cross section");
 	}
     std::cout << "Healthy finish!" << std::endl;
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,6 +108,9 @@ int main(int argc, char **argv) {
 
 		data = res[1].get();
 		writeImage("heightID.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru height ID");
+        
+        data = res[2].get();
+		writeImage("cross.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru cross section");
 	}
     std::cout << "Healthy finish!" << std::endl;
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,7 @@ int main(int argc, char **argv) {
     
     // Create the view we want to render:
     Ashigaru::TripleAction program{tile_width, tile_height};
+    
     auto models = server.RegisterModels(std::vector<std::shared_ptr<Model>>{geometry, partner_geom});
     auto view = server.RegisterView(program, 2*width, height, models).get();
     
@@ -103,10 +104,10 @@ int main(int argc, char **argv) {
 		std::vector<std::future<std::unique_ptr<char>>> res = server.ViewSlice(view, vm["slice"].as<size_t>());
 		// wait for results and save them:
 		std::unique_ptr<char> data = std::move(res[0].get());
-		writeImage("dump.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru slice");
+		writeImage("height.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru height");
 
-		//data = res[1].get();
-		//writeImage("depth.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru depth");
+		data = res[1].get();
+		writeImage("heightID.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru height ID");
 	}
     std::cout << "Healthy finish!" << std::endl;
     return 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,10 +70,13 @@ int main(int argc, char **argv) {
     std::vector<std::shared_ptr<Model>> masterAssembly;
 
     float fltMax = std::numeric_limits<float>::max();
+    size_t assemblyVertCount = 0;
     Vertex maxV{ 0., 0., 0. }, minV{ fltMax, fltMax, fltMax };
     for (auto& modelName : modelNames) {
         std::shared_ptr<Model> geometry = std::make_shared<Model>(readBinarySTL(modelName.c_str()));
-        std::cout << geometry->first.size() << "\n";
+        std::cout << geometry->first.size() << std::endl;
+        assemblyVertCount += geometry->first.size();
+
         for (auto& vertex : geometry->first) // find bounding box
         {
             maxV = glm::max(vertex, maxV);
@@ -81,6 +84,8 @@ int main(int argc, char **argv) {
         }
         masterAssembly.push_back(geometry);
     }
+    std::cout << "Assembly total vertex count: " << assemblyVertCount << std::endl;
+
     glm::vec3 dims = maxV - minV;
     Vertex::value_type maxDim = std::max({ dims.x, dims.y, dims.z });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "geometry.h"
 #include "opengl_utils.h"
 #include "render_server.h"
+#include "triple_action.h"
 
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/string_cast.hpp>
@@ -45,7 +46,7 @@ int main(int argc, char **argv) {
     
     // Load a model, do Q&D size-to-fit and then duplicate it.
     // the two models are the (possibly) rendered scene.
-    std::shared_ptr<Model> geometry = std::make_shared<Model>(readBinarySTL("models/donkey.stl"));
+    std::shared_ptr<Model> geometry = std::make_shared<Model>(readBinarySTL("models/Donkey.stl"));
     Vertex maxV{ 0., 0., 0. }, minV{ 20000, 20000, 20000 };
     for (auto& vertex : geometry->first) // find bounding box
     {
@@ -70,7 +71,7 @@ int main(int argc, char **argv) {
     Ashigaru::RenderServer server(tile_width, tile_height);
     
     // Create the view we want to render:
-    Ashigaru::TestRenderAction program{tile_width, tile_height};
+    Ashigaru::TripleAction program{tile_width, tile_height};
     auto models = server.RegisterModels(std::vector<std::shared_ptr<Model>>{geometry, partner_geom});
     auto view = server.RegisterView(program, 2*width, height, models).get();
     
@@ -81,15 +82,16 @@ int main(int argc, char **argv) {
 		std::vector<std::vector<std::future<std::unique_ptr<char>>>> slices;
 
 		auto start = std::chrono::system_clock::now();
-		for (size_t slice = 0; slice < 500; ++slice) {
+		for (size_t slice = 0; slice < 100; ++slice) {
 			slices.push_back(server.ViewSlice(view, slice));
 		}
 		auto end = std::chrono::system_clock::now();
 
 		while (slices.size()) {
 			auto& slice = slices.back();
-			slice[0].get();
-			slice[1].get();
+            for (auto& map : slice)
+                map.get();
+			
 			slices.pop_back();
 		}
 		auto fullEnd = std::chrono::system_clock::now();
@@ -103,8 +105,8 @@ int main(int argc, char **argv) {
 		std::unique_ptr<char> data = std::move(res[0].get());
 		writeImage("dump.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru slice");
 
-		data = res[1].get();
-		writeImage("depth.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru depth");
+		//data = res[1].get();
+		//writeImage("depth.png", 2 * width, height, ImageType::Gray, data.get(), "Ashigaru depth");
 	}
     std::cout << "Healthy finish!" << std::endl;
     return 0;

--- a/src/tiled_view.cpp
+++ b/src/tiled_view.cpp
@@ -142,24 +142,18 @@ TiledView::TiledView(
             // if a face touches the tile, take all its vertices to this tile's list.
             // Future: maybe just work with faces and glDrawElements()?
             std::vector<Vertex> tile_verts;
-            std::vector<unsigned short> shell_IDs;
-            unsigned short shell_ID = 0;
+            size_t start = 0;
             for (auto model : m_models) {
                 auto num_taken = TakeTouchingFaces(*model, tile.region, tile_verts);
-                shell_IDs.insert(shell_IDs.end(), num_taken, shell_ID++ );
+                tile.vertices.AddModelIndex(start, num_taken);
+                start += num_taken;
             }
-            tile.vertices.SetNumVerts(tile_verts.size());
             
             GLuint vert_buf, shellIds_buf;
             glGenBuffers(1, &vert_buf);
             glBindBuffer(GL_ARRAY_BUFFER, vert_buf);
             glBufferData(GL_ARRAY_BUFFER, tile_verts.size()*sizeof(Vertex), tile_verts.data(), GL_STATIC_DRAW);
             tile.vertices.AddBuffer("positions", vert_buf);
-            
-            glGenBuffers(1, &shellIds_buf);
-            glBindBuffer(GL_ARRAY_BUFFER, shellIds_buf);
-            glBufferData(GL_ARRAY_BUFFER, shell_IDs.size()*sizeof(unsigned short), shell_IDs.data(), GL_STATIC_DRAW);
-            tile.vertices.AddBuffer("shellIDs", shellIds_buf);
             
             m_tiles.push_back(tile);
         }


### PR DESCRIPTION
https://grabcad.atlassian.net/browse/GC-52461

### description

Generate all STL maps, using the method of rendering each object instead of grouping objects to one render. The renders are *not* pixel perfect, just good enough to get realistic measures.

The main changes:
1. TripleAction added, a RenderAction that generated the 3 maps requested in this ticket.
2. Loading shaders extended to load a geometry shader and seen some janitoring.
3. main.cpp extended with options to do model repeats as one or many models and to read assemblies.
4. Tile division sped up.

There is a known problem with the tile division, and the algorithm will need to be improved when we start real work. But I think it does well enough to prove the concept.

### Test
Any model will do, there are some in the models/ directory. Try with --repeats <number>
For example, 
```  
.\Ashigaru\x64\Release\Ashigaru.exe .\models\crystal.stl --img-size 11264 --repeats 40
```

This runs your scene 10 times and prints timing information. To run just one time and get viewable results, add `--slice <number>`. You get 3 new png files for cross, height and heightID.

The toughest cookie is the dwarves assembly. Unzip this in the top ashigaru directory:
O:\R&D DATA\YosefM\dwarves.tar.gz

You get a text file describing the assembly and the individual STLs are unpacked into models/tavor_dwarves/

I ran it with these command-line arguments:
```
dwarves_assembly.txt --img-size 11264 --repeats 5 
```